### PR TITLE
Tile loading performance improvements.

### DIFF
--- a/MapboxAndroidSDK/build.gradle
+++ b/MapboxAndroidSDK/build.gradle
@@ -256,15 +256,30 @@ afterEvaluate { project ->
 task uploadToNexus(type: Upload, dependsOn: build) {
     configuration = configurations.archives
     repositories.mavenDeployer {
-        // Ensure gradle works without properties defined
+        /**
+         * Note: to upload the archive the developer must specify the username and password in their gradle
+         * properties file:
+         *    ~/.gradle/gradle.properties
+         *       mavenUser=admin
+         *       mavenPassword=myAdminPassword
+         *
+         * Alternative: it is possible to pass in a property to the build like the following.
+         *
+         *    ./gradle uploadArchives -PsonatypeUsername=MysticalDeployer -PsonatypePassword=password1
+         *
+         *    authentication(userName: project.hasProperty("sonatypeUsername") ?
+         *              project.sonatypeUsername : null, password: project.hasProperty("sonatypePassword") ?
+         *              project.sonatypePassword : null)
+         *
+         */
         ext.mavenUser = project.hasProperty('mavenUser') ? project.getProperty('mavenUser') : 'unspecified'
         ext.mavenPassword = project.hasProperty('mavenPassword') ? project.getProperty('mavenPassword') : 'unspecified'
 
         repository(url: "http://nexus-ordnancesurvey.rhcloud.com/nexus/content/repositories/releases") {
-            authentication(userName: "circleci", password: "circlebuild")
+            authentication(userName: mavenUser, password: mavenPassword)
         }
         snapshotRepository(url: "http://nexus-ordnancesurvey.rhcloud.com/nexus/content/repositories/snapshots") {
-            authentication(userName: "circleci", password: "circlebuild")
+            authentication(userName: mavenUser, password: mavenPassword)
         }
 
         pom.project {

--- a/MapboxAndroidSDK/build.gradle
+++ b/MapboxAndroidSDK/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.2'
+        classpath 'com.android.tools.build:gradle:1.2.3'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.10.1'
     }
 }
@@ -285,6 +285,7 @@ task uploadToNexus(type: Upload, dependsOn: build) {
         pom.project {
             name 'Mapbox Android raster SDK'
             packaging 'aar'
+            artifactId 'mapbox-android-sdk'
             description 'OS Fork of Mapbox Android raster SDK'
             delegate.url 'https://github.com/OrdnanceSurvey/mapbox-android-sdk'
 

--- a/MapboxAndroidSDK/build.gradle
+++ b/MapboxAndroidSDK/build.gradle
@@ -252,3 +252,51 @@ afterEvaluate { project ->
         archives androidJavadocsJar
     }
 }
+
+task uploadToNexus(type: Upload, dependsOn: build) {
+    configuration = configurations.archives
+    repositories.mavenDeployer {
+        // Ensure gradle works without properties defined
+        ext.mavenUser = project.hasProperty('mavenUser') ? project.getProperty('mavenUser') : 'unspecified'
+        ext.mavenPassword = project.hasProperty('mavenPassword') ? project.getProperty('mavenPassword') : 'unspecified'
+
+        repository(url: "http://nexus-ordnancesurvey.rhcloud.com/nexus/content/repositories/releases") {
+            authentication(userName: "circleci", password: "circlebuild")
+        }
+        snapshotRepository(url: "http://nexus-ordnancesurvey.rhcloud.com/nexus/content/repositories/snapshots") {
+            authentication(userName: "circleci", password: "circlebuild")
+        }
+
+        pom.project {
+            name 'Mapbox Android raster SDK'
+            packaging 'aar'
+            description 'OS Fork of Mapbox Android raster SDK'
+            delegate.url 'https://github.com/OrdnanceSurvey/mapbox-android-sdk'
+
+            licenses {
+                license {
+                    name 'The Apache Software License, Version 2.0'
+                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    distribution 'repo'
+                }
+            }
+
+            scm {
+                delegate.url 'scm:git@github.com:OrdnanceSurvey/mapbox-android-sdk.git'
+                connection 'scm:git@github.com:OrdnanceSurvey/mapbox-android-sdk.git'
+                developerConnection 'scm:git@github.com:OrdnanceSurvey/mapbox-android-sdk.git'
+            }
+
+            developers {
+                developer {
+                    id 'snodnipper'
+                    name 'Snodnipper'
+                }
+                developer {
+                    id 'drhaynes'
+                    name 'drhaynes'
+                }
+            }
+        }
+    }
+}

--- a/MapboxAndroidSDK/gradle.properties
+++ b/MapboxAndroidSDK/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.mapbox.mapboxsdk
-VERSION_NAME=0.7.4-SNAPSHOT
+VERSION_NAME=0.7.4-OS-SNAPSHOT
 
 POM_DESCRIPTION=Mapbox SDK
 POM_URL=https://github.com/mapbox/mapbox-android-sdk

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTile.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTile.java
@@ -42,7 +42,7 @@ public class MapTile implements GeoConstants, MapboxConstants, TileLayerConstant
         this.z = az;
         this.x = ax;
         this.y = ay;
-        this.path = String.format(MAPBOX_LOCALE, "%d/%d/%d", z, x, y);
+        this.path = (new StringBuilder()).append(z).append('/').append(x).append('/').append(y).toString();
         this.cacheKey = aCacheKey + "/" + path;
         this.code = ((17 * (37 + z)) * (37 * x)) * (37 + y);
     }

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/constants/TileLayerConstants.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/constants/TileLayerConstants.java
@@ -40,5 +40,5 @@ public interface TileLayerConstants {
      */
     public static final int NUMBER_OF_TILE_DOWNLOAD_THREADS = 8;
 
-    public static final int TILE_DOWNLOAD_MAXIMUM_QUEUE_SIZE = 40;
+    public static final int TILE_DOWNLOAD_MAXIMUM_QUEUE_SIZE = 8;
 }

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/util/MapboxUtils.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/util/MapboxUtils.java
@@ -114,7 +114,8 @@ public class MapboxUtils implements MapboxConstants {
     }
 
     public static String getMapTileURL(Context context, String mapID, int zoom, int x, int y, RasterImageQuality imageQuality) {
-        return String.format(MAPBOX_LOCALE, MAPBOX_BASE_URL_V4 + "%s/%d/%d/%d%s.%s?access_token=%s", mapID, zoom, x, y, "", MapboxUtils.qualityExtensionForImageQuality(imageQuality), MapboxUtils.getAccessToken());
+        return (new StringBuilder(MAPBOX_BASE_URL_V4)).append(mapID).append('/').append(zoom).append('/').append(x).append('/').append(y).append('.').
+                append(MapboxUtils.qualityExtensionForImageQuality(imageQuality)).append("?access_token=").append(MapboxUtils.getAccessToken()).toString();
     }
 
     /**

--- a/MapboxAndroidSDKTestApp/build.gradle
+++ b/MapboxAndroidSDKTestApp/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.2'
+        classpath 'com.android.tools.build:gradle:1.2.3'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.10.1'
     }
 }


### PR DESCRIPTION
Quick win for now that requires testing across a number of devices to verify improvements work independently of screen sizes. Seems good on the Nexus 4 and S3 though.
- Improve tile loading performance during fast map interactions by using a smaller max queue size.
- Also, use stringbuilder for tile request performance improvements. Stolen mercilessly from https://github.com/mapbox/mapbox-android-sdk/pull/737 - so worth keeping an eye on if/when that PR gets merged.
