### PR TITLE
Fix for tiles not loading during pinch zoom map interaction.

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapViewScaleGestureDetectorListener.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapViewScaleGestureDetectorListener.java
@@ -11,12 +11,30 @@ import android.view.ScaleGestureDetector;
 public class MapViewScaleGestureDetectorListener implements ScaleGestureDetector.OnScaleGestureListener {
 
     private static String TAG = "MapViewScaleListener";
+    private static final int SCALE_END_DELAY_MS = 50;
+
+    /**
+     * When zooming, how often we should update the map's internal zoom level state.
+     * This allows loading of tiles for a different zoom level, rather than merely scaling
+     * what has already been drawn.
+     */
+    private static final int ZOOM_LEVEL_UPDATE_DELAY_MS = 300;
+
+    /**
+     * Time since the map view's internal zoom levels were last updated.
+     */
+    private long previousTimeMillis = 0;
+
+    /**
+     * Delay value to wait until we reset map animation state - this is to allow the map
+     * to have time to make tile requests when switching internal zoom levels in onScale()
+     */
+    private static final int RESET_MAP_ANIMATION_STATE_DELAY_MS = 50;
 
     /**
      * This is the active focal point in terms of the viewport. Could be a local
      * variable but kept here to minimize per-frame allocations.
      */
-
     private float lastFocusX;
     private float lastFocusY;
     private float firstSpan;
@@ -42,8 +60,10 @@ public class MapViewScaleGestureDetectorListener implements ScaleGestureDetector
         if (!this.mapView.isAnimating()) {
             this.mapView.setIsAnimating(true);
             this.mapView.getController().aboutToStartAnimation(lastFocusX, lastFocusY);
-            scaling = true;
         }
+        scaling = true;
+
+        previousTimeMillis = System.currentTimeMillis();
         return true;
     }
 
@@ -52,17 +72,51 @@ public class MapViewScaleGestureDetectorListener implements ScaleGestureDetector
         if (!scaling) {
             return true;
         }
-        currentScale = detector.getCurrentSpan() / firstSpan;
 
+        currentScale = detector.getCurrentSpan() / firstSpan;
+        long deltaTime = System.currentTimeMillis() - previousTimeMillis;
         float focusX = detector.getFocusX();
         float focusY = detector.getFocusY();
 
-        this.mapView.setScale(currentScale);
+        if (deltaTime > ZOOM_LEVEL_UPDATE_DELAY_MS) {
+            // This rather nasty bit of code is responsible for updating the map tile zoom level,
+            // enabling async tile loading when the map changes zoom level during a pinch.
+            float preZoom = mapView.getZoomLevel(false);
+            float newZoom = (float) (Math.log(currentScale) / Math.log(2d) + preZoom);
+
+            // Calling these sets (through the magic of side-effects) the state of the mapView to
+            // match the newly calculated zoom level and kicks off tile loading.
+            mapView.setAnimatedZoom(newZoom);
+            mapView.getController().onAnimationEnd();
+            mapView.getController().aboutToStartAnimation(lastFocusX, lastFocusY);
+
+            // Dirty hack to give the mapView enough time to request tiles before we reset its
+            // internal state fully. Not doing this kills all tile requests before they have a
+            // chance to start.
+            final Handler handler = new Handler();
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mapView.setIsAnimating(true);
+                }
+            }, RESET_MAP_ANIMATION_STATE_DELAY_MS);
+
+            // Reset scaling & position state for next time round - needed for zoom calculations.
+            firstSpan = detector.getCurrentSpan();
+            currentScale = 1.0f;
+
+            previousTimeMillis = System.currentTimeMillis();
+        } else {
+            // We aren't redrawing tiles for an updated zoom level - simple scaling will suffice.
+            this.mapView.setScale(currentScale);
+        }
+
+        // Panning can happen independently of scaling and updating map zoom level.
         this.mapView.getController().offsetDeltaScroll(lastFocusX - focusX, lastFocusY - focusY);
         this.mapView.getController().panBy(lastFocusX - focusX, lastFocusY - focusY, true);
-
         lastFocusX = focusX;
         lastFocusY = focusY;
+
         return true;
     }
 
@@ -83,9 +137,10 @@ public class MapViewScaleGestureDetectorListener implements ScaleGestureDetector
                 //set animated zoom so that animationEnd will correctly set it in the mapView
                 mapView.setAnimatedZoom(newZoom);
                 mapView.getController().onAnimationEnd();
+                mapView.setIsAnimating(false);
                 scaling = false;
             }
-        }, 100);
+        }, SCALE_END_DELAY_MS);
 
     }
 }


### PR DESCRIPTION
This is a hacky stop-gap solution, rather than a proper fix (which would require substantial re-engineering). The proper fix probably involves a combination of refactoring of the mapView, better gesture handling, and using Glide for image loading, as outlined here: https://github.com/mapbox/mapbox-android-sdk/issues/482

That said, this now allows for the map to load tiles during an interactive zoom, which is a step towards addressing several of the issues we've been seeing with the MB Android sdk.

It also further highlights an associated problem of tiles being incorrectly invalidated and general tile drawing jankiness, which is next on the agenda to address. MB issue related to that here for background: https://github.com/mapbox/mapbox-android-sdk/issues/401
