### PR TITLE
Fix mbtiles loading when filename does not have a dot extension

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/MBTilesLayer.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/MBTilesLayer.java
@@ -36,7 +36,7 @@ public class MBTilesLayer extends TileLayer implements MapViewConstants, MapboxC
      * @param context the graphics drawing context
      */
     public MBTilesLayer(final Context context, final String url) {
-        super(url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('.')), url);
+        super(url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('.') > 0 ? url.lastIndexOf('.') : url.length() - 1), url);
         initialize(url, context);
     }
 


### PR DESCRIPTION
This fixes an index out of bounds exception we were seeing when trying to load mbtiles packages that do not have an extension, e.g. 'somePackage' as opposed to 'somePackage.mbtiles'
