### PR TITLE
Always return true for MapTileLayerArray.networkAvailable()

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTileLayerArray.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTileLayerArray.java
@@ -91,7 +91,10 @@ public class MapTileLayerArray extends MapTileLayerBase {
     }
 
     private boolean networkAvailable() {
-        return mNetworkAvailabilityCheck == null || mNetworkAvailabilityCheck.getNetworkAvailable();
+        // Always return true to workaround issue where MBTiles don't load
+        // Mapbox issue: https://github.com/mapbox/mapbox-android-sdk/issues/595
+        // TODO: Ollie wants to fix this properly ;-p
+        return true;
     }
 
     /**


### PR DESCRIPTION
Workaround as per: https://github.com/mapbox/mapbox-android-sdk/issues/595
